### PR TITLE
Refresh swift-syntax compatibility checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,5 +143,4 @@ jobs:
         uses: davdroman/swift-syntax-compatibility-check@v1
         with:
           run-tests: false
-          from-version: "601.0.0"
           major-versions-only: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v5
 
-      - name: Run Swift Syntax Compatibility Check
+      - name: Check Swift Syntax Compatibility
         uses: davdroman/swift-syntax-compatibility-check@v1
         with:
           run-tests: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Run Swift Syntax Compatibility Check
-        uses: davdroman/swift-syntax-compatibility-check@main
+        uses: davdroman/swift-syntax-compatibility-check@v1
         with:
           run-tests: false
           from-version: "601.0.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Run Swift Syntax Compatibility Check
-        uses: davdroman/swift-macro-compatibility-check@main
+        uses: davdroman/swift-syntax-compatibility-check@main
         with:
           run-tests: false
           from-version: "601.0.0"

--- a/Package.swift
+++ b/Package.swift
@@ -44,7 +44,7 @@ let package = Package(
 
 package.dependencies += [
 	.package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.6.0"),
-	.package(url: "https://github.com/swiftlang/swift-syntax", "600.0.0"..<"604.0.0"),
+	.package(url: "https://github.com/swiftlang/swift-syntax", "600.0.0"..<"605.0.0"),
 ]
 
 for target in package.targets {


### PR DESCRIPTION
## Summary
- raise the `swift-syntax` upper bound to `..<605.0.0`
- point CI at the renamed `swift-syntax-compatibility-check` action