### PR TITLE
CI: Fix SwiftSyntax compatibility check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,11 @@ jobs:
       - name: Disable SwiftSyntax Prebuilts
         # TODO: Drop or update Swift version constraint as prebuilts become available
         if: ${{ matrix.swift == '6.3' }}
-        uses: davdroman/disable-swift-syntax-prebuilts@v1
+        run: |
+          defaults write com.apple.dt.Xcode IDEPackageEnablePrebuilts -bool NO
+          rm -rf ~/Library/Developer/Xcode/DerivedData
+          rm -rf ~/Library/Developer/Xcode/SourcePackages
+          rm -rf ~/Library/Caches/org.swift.swiftpm
 
       - if: ${{ matrix.platform != 'macOS' && matrix.platform != 'mac-catalyst' }}
         name: Initialize Simulator Service

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,9 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v5
 
+      - name: Disable SwiftSyntax Prebuilts
+        uses: davdroman/disable-swift-syntax-prebuilts@v1
+
       - name: Check Swift Syntax Compatibility
         uses: davdroman/swift-syntax-compatibility-check@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,11 +67,7 @@ jobs:
       - name: Disable SwiftSyntax Prebuilts
         # TODO: Drop or update Swift version constraint as prebuilts become available
         if: ${{ matrix.swift == '6.3' }}
-        run: |
-          defaults write com.apple.dt.Xcode IDEPackageEnablePrebuilts -bool NO
-          rm -rf ~/Library/Developer/Xcode/DerivedData
-          rm -rf ~/Library/Developer/Xcode/SourcePackages
-          rm -rf ~/Library/Caches/org.swift.swiftpm
+        uses: davdroman/disable-swift-syntax-prebuilts@v1
 
       - if: ${{ matrix.platform != 'macOS' && matrix.platform != 'mac-catalyst' }}
         name: Initialize Simulator Service

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,11 +135,9 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v5
 
-      - name: Disable SwiftSyntax Prebuilts
-        uses: davdroman/disable-swift-syntax-prebuilts@v1
-
       - name: Check Swift Syntax Compatibility
-        uses: davdroman/swift-syntax-compatibility-check@v1
+        uses: davdroman/swift-syntax-compatibility-check@disable-prebuilts-input
         with:
           run-tests: false
           major-versions-only: true
+          disable-prebuilts: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Check Swift Syntax Compatibility
-        uses: davdroman/swift-syntax-compatibility-check@disable-prebuilts-input
+        uses: davdroman/swift-syntax-compatibility-check@v1
         with:
           run-tests: false
           major-versions-only: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
 
   check-swift-syntax-compatibility:
     name: Swift Syntax Compatibility Check
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - name: Git Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- Pin the SwiftSyntax compatibility job to macOS 26 so it exercises the runner family that downloads SwiftSyntax prebuilts
- Use davdroman/swift-syntax-compatibility-check@v1 with disable-prebuilts: true for the SwiftPM compatibility path
- Leave the apple job's existing inline prebuilt-disabling step in place